### PR TITLE
Patch `smlnj.nix` for darwin

### DIFF
--- a/NixOS/pkgs/smlnj.nix
+++ b/NixOS/pkgs/smlnj.nix
@@ -102,7 +102,9 @@ in
       patchPhase = ''
         sed -i '/^PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
         echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
-      '';
+      '' + (if stdenv.isDarwin then ''
+        sed -i 's:INCLFILE=.*$:INCLFILE=${stdenv.cc.libc}/include/unistd.h:' base/runtime/config/gen-posix-names.sh
+      '' else "");
 
       unpackPhase = ''
         for s in $sources; do

--- a/NixOS/pkgs/smlnj.nix
+++ b/NixOS/pkgs/smlnj.nix
@@ -102,9 +102,9 @@ in
       patchPhase = ''
         sed -i '/^PATH=/d' config/_arch-n-opsys base/runtime/config/gen-posix-names.sh
         echo SRCARCHIVEURL="file:/$TMP" > config/srcarchiveurl
-      '' + (if stdenv.isDarwin then ''
-        sed -i 's:INCLFILE=.*$:INCLFILE=${stdenv.cc.libc}/include/unistd.h:' base/runtime/config/gen-posix-names.sh
-      '' else "");
+      '' + lib.optionalString stdenv.isDarwin ''
+        sed -i '/^INCLFILE=/c INCLFILE=${stdenv.cc.libc}/include/unistd.h' base/runtime/config/gen-posix-names.sh
+      '';
 
       unpackPhase = ''
         for s in $sources; do


### PR DESCRIPTION
On Darwin, the `gen-posix-names.sh` script uses the path to `xcrun` (an XCode utility) to figure out where `<unistd.h>` is, but the `xcrun` wrapper provided by nixpkgs does not come with the C library.